### PR TITLE
Added transaction fees + started slippage

### DIFF
--- a/src/bullets/data_source/data_source_interface.py
+++ b/src/bullets/data_source/data_source_interface.py
@@ -20,9 +20,6 @@ class DataSourceInterface:
     def get_price(self, symbol: str, timestamp:datetime = None):
         pass
 
-    def get_market_open_close(self):
-        pass
-
     @staticmethod
     def request(url: str, method: str = "GET", body=None) -> str:
         """

--- a/src/bullets/portfolio/transaction.py
+++ b/src/bullets/portfolio/transaction.py
@@ -3,16 +3,20 @@ class Transaction:
     STATUS_FAILED_INSUFFICIENT_FUNDS = "Failed - Insufficient Funds"
     STATUS_FAILED_SYMBOL_NOT_FOUND = "Failed - Symbol couldn't be found"
 
-    def __init__(self, symbol: str, nb_shares: float, price: float, timestamp, status: str):
+    def __init__(self, symbol: str, nb_shares: float, theoretical_price: float, simulated_price: float, timestamp, status: str, transaction_fees: int):
         """
         Args:
             symbol (str): symbol for the stock (i.e. AAPL)
             nb_shares (float): Number of shares
-            price (float): Price of the shares
+            theoretical_price (float): Theoretical price of the shares
+            simulated_price (float): Simulated price (with slippage) of the shares
             timestamp: Time of the transaction
+            transaction_fees: Fees of the transaction
         """
         self.symbol = symbol
         self.nb_shares = nb_shares
-        self.price = price
+        self.theoretical_price = theoretical_price
+        self.simulated_price = simulated_price
         self.timestamp = timestamp
         self.status = status
+        self.transaction_fees = transaction_fees

--- a/src/bullets/strategy.py
+++ b/src/bullets/strategy.py
@@ -35,12 +35,11 @@ class Strategy:
                                    self.transaction_fees)
         self.validate_start_data()
 
-    """
-        Extend this method to perform an operation that will be run on every resolution.
-    """
-
     @abstractmethod
     def on_resolution(self):
+        """
+            Extend this method to perform an operation that will be run on every resolution.
+        """
         pass
 
     def update_time(self, timestamp):

--- a/src/bullets/strategy.py
+++ b/src/bullets/strategy.py
@@ -8,29 +8,37 @@ __all__ = ["Strategy"]
 
 
 class Strategy:
-
     """
     Base class for trading strategies. Extend this class and override the setup and on_resolution functions to make
     your own strategy.
     """
+
     def __init__(self,
                  resolution: Resolution,
                  start_time: datetime,
                  end_time: datetime,
                  starting_balance: float,
-                 data_source: DataSourceInterface):
+                 data_source: DataSourceInterface,
+                 slippage_percent: int = 25,
+                 transaction_fees: int = 1):
         self.resolution = resolution
         self.start_time = start_time
         self.end_time = end_time
         self.starting_balance = starting_balance
         self.data_source = data_source
-        self.portfolio = Portfolio(starting_balance, self.data_source)
+        self.slippage_percent = slippage_percent
+        self.transaction_fees = transaction_fees
         self.timestamp = None
+        self.portfolio = Portfolio(self.starting_balance,
+                                   self.data_source,
+                                   self.slippage_percent,
+                                   self.transaction_fees)
         self.validate_start_data()
 
     """
         Extend this method to perform an operation that will be run on every resolution.
     """
+
     @abstractmethod
     def on_resolution(self):
         pass
@@ -54,3 +62,9 @@ class Strategy:
 
         if self.starting_balance is None or self.starting_balance <= 0:
             raise ValueError("Strategy starting balance should be positive")
+
+        if self.slippage_percent is None or self.slippage_percent < 0 or self.slippage_percent > 100:
+            raise ValueError("Slippage percent should be between 0 and 100")
+
+        if self.transaction_fees is None or self.transaction_fees < 0:
+            raise ValueError("Transaction fees should be positive or 0")

--- a/src/test/test_portfolio.py
+++ b/src/test/test_portfolio.py
@@ -12,31 +12,31 @@ class TestPortfolio(unittest.TestCase):
 
     @mock.patch('bullets.data_source.data_source_interface.DataSourceInterface.get_price', return_value=1)
     def test_buy_sell_long(self, mock_get_price):
-        portfolio = Portfolio(1000, DataSourceInterface())
-        transaction = portfolio.market_order("AAPL", 1000)
+        portfolio = Portfolio(1000, DataSourceInterface(), 25, 1)
+        transaction = portfolio.market_order("AAPL", 999)
         self.assertEqual(Transaction.STATUS_SUCCESSFUL, transaction.status)
         self.assertEqual(0, portfolio.cash_balance)
-        transaction = portfolio.market_order("AAPL", -1000)
+        transaction = portfolio.market_order("AAPL", -999)
         self.assertEqual(Transaction.STATUS_SUCCESSFUL, transaction.status)
-        self.assertEqual(1000, portfolio.cash_balance)
+        self.assertEqual(998, portfolio.cash_balance)
         self.assertEqual(0, len(portfolio.holdings))
         self.assertEqual(2, len(portfolio.transactions))
 
     @mock.patch('bullets.data_source.data_source_interface.DataSourceInterface.get_price', return_value=1)
     def test_buy_sell_short(self, mock_get_price):
-        portfolio = Portfolio(1000, DataSourceInterface())
+        portfolio = Portfolio(1000, DataSourceInterface(), 25, 1)
         transaction = portfolio.market_order("AAPL", -1000)
         self.assertEqual(Transaction.STATUS_SUCCESSFUL, transaction.status)
-        self.assertEqual(2000, portfolio.cash_balance)
+        self.assertEqual(1999, portfolio.cash_balance)
         transaction = portfolio.market_order("AAPL", 1000)
         self.assertEqual(Transaction.STATUS_SUCCESSFUL, transaction.status)
-        self.assertEqual(1000, portfolio.cash_balance)
+        self.assertEqual(998, portfolio.cash_balance)
         self.assertEqual(0, len(portfolio.holdings))
         self.assertEqual(2, len(portfolio.transactions))
 
     @mock.patch('bullets.data_source.data_source_interface.DataSourceInterface.get_price', return_value=1)
     def test_insufficient_funds(self, mock_get_price):
-        portfolio = Portfolio(1000, DataSourceInterface())
+        portfolio = Portfolio(1000, DataSourceInterface(), 25, 1)
         transaction = portfolio.market_order("AAPL", 2000)
         self.assertEqual(Transaction.STATUS_FAILED_INSUFFICIENT_FUNDS, transaction.status)
         self.assertEqual(1000, portfolio.cash_balance)
@@ -45,13 +45,13 @@ class TestPortfolio(unittest.TestCase):
 
     def test_market_order(self):
         data_source = FmpDataSource('878bd792d690ec6591d21a52de0b6774', Resolution.MINUTE)
-        portfolio = Portfolio(1000, data_source)
+        portfolio = Portfolio(1000, data_source, 25, 1)
         portfolio.timestamp = datetime.datetime(2019, 3, 12, 15, 57)
         data_source.timestamp = datetime.datetime(2019, 3, 12, 15, 57)
         portfolio.market_order('AAPL', 5)
         data_source.timestamp = datetime.datetime(2019, 3, 13, 15, 57)
         portfolio.timestamp = datetime.datetime(2019, 3, 13, 15, 57)
-        self.assertEqual(1004.8499999999999, portfolio.update_and_get_balance())
+        self.assertEqual(1003.8499999999999, portfolio.update_and_get_balance())
 
 
 if __name__ == '__main__':

--- a/src/test/test_strategy.py
+++ b/src/test/test_strategy.py
@@ -23,9 +23,9 @@ class TestPortfolio(unittest.TestCase):
         runner = Runner(strategy)
         runner.start()
         self.assertEqual(5000, strategy.portfolio.start_balance)
-        self.assertEqual(5489.624975, strategy.portfolio.update_and_get_balance())
-        self.assertEqual(120.71247499999933, strategy.portfolio.cash_balance)
-        self.assertEqual(9.79, strategy.portfolio.get_percentage_profit())
+        self.assertEqual(5468.624975, strategy.portfolio.update_and_get_balance())
+        self.assertEqual(99.71247499999933, strategy.portfolio.cash_balance)
+        self.assertEqual(9.37, strategy.portfolio.get_percentage_profit())
         self.assertEqual(34, len(strategy.portfolio.transactions))
 
     def test_strategy_none_date(self):


### PR DESCRIPTION
Added transaction fees logic to portfolio and strategy
Added slippage logic to strategy
Started slippage calculation on market order
Changed test_startegy values to take into account the transaction fees
Added simulated price to transaction (wich is the price with slippage) and change the price parameter to theoretical_price

Need to merge this to get cachePriceData changes and then add slippage